### PR TITLE
Try resolving an error loading the Gradle project in IntelliJ IDEA 2024.3 and bump the Gradle Wrapper to v8.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ configurations.all {
 
 1. IntelliJ IDEA doesn't work well with applying plugins to script plugins in project sources. If a script plugin's code does not resolve, try restarting IntelliJ IDEA.
 1. `./gradlew build` (and tasks depending on it) somehow has to run twice to work. I haven't identified the cause yet.
+1. IntelliJ IDEA 2024.3 doesn't load this project, which is reported at [IDEA-363846](https://youtrack.jetbrains.com/issue/IDEA-363846/Loading-a-Gradle-project-of-Gradle-plugins-changes-a-final-Kotlin-freeCompilerArgs-since-IntelliJ-IDEA-2024.3).

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -26,8 +26,8 @@ dependencies {
     */
     // for `KotlinCompilationTask` and the version is compatible with Compose 1.6.11
     // With Kotlin 2.0.20, a "Could not parse POM" build error occurs in the JVM projects of some dependent projects.
-    implementation(kotlin("gradle-plugin", "2.0.10"))
-    implementation("org.gradle.kotlin:gradle-kotlin-dsl-plugins:4.5.0") // This version has to be used for Gradle 8.10.
+    implementation(kotlin("gradle-plugin", "2.0.20"))
+    implementation("org.gradle.kotlin:gradle-kotlin-dsl-plugins:5.1.1") // This version has to be used for Gradle 8.11.2.
 
     implementation("com.gradle.publish:plugin-publish-plugin:1.3.0")
 

--- a/buildSrc/src/main/kotlin/aligned-version-plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/aligned-version-plugin-conventions.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-
 plugins {
     id("conventions")
     id("aligned-version-plugin-version")
@@ -10,6 +8,8 @@ dependencies {
     implementation("com.huanshankeji:common-gradle-dependencies:$pluginProjectSourceDependentStableCommonGradleDependenciesVersion")
 }
 
+/*
 tasks.named<KotlinCompilationTask<*>>("compileKotlin").configure {
     compilerOptions.freeCompilerArgs.add("-opt-in=com.huanshankeji.InternalApi")
 }
+*/

--- a/buildSrc/src/main/kotlin/aligned-version-plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/aligned-version-plugin-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     id("conventions")
     id("aligned-version-plugin-version")
@@ -8,8 +10,6 @@ dependencies {
     implementation("com.huanshankeji:common-gradle-dependencies:$pluginProjectSourceDependentStableCommonGradleDependenciesVersion")
 }
 
-/*
 tasks.named<KotlinCompilationTask<*>>("compileKotlin").configure {
     compilerOptions.freeCompilerArgs.add("-opt-in=com.huanshankeji.InternalApi")
 }
-*/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/Internal.kt
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/Internal.kt
@@ -1,6 +1,5 @@
 package com.huanshankeji
 
-@RequiresOptIn
+@RequiresOptIn("This API is internal in this project.", RequiresOptIn.Level.WARNING) // TODO consider removing `WARNING`
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.PROPERTY)
 annotation class InternalApi

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/Internal.kt
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/Internal.kt
@@ -1,5 +1,5 @@
 package com.huanshankeji
 
-@RequiresOptIn("This API is internal in this project.", RequiresOptIn.Level.WARNING) // TODO consider removing `WARNING`
+@RequiresOptIn("This API is internal in this project.")
 @Retention(AnnotationRetention.BINARY)
 annotation class InternalApi


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/IDEA-363846/Loading-a-Gradle-project-of-Gradle-plugins-changes-a-final-Kotlin-freeCompilerArgs-since-IntelliJ-IDEA-2024.3.

Kotlin is bumped to 2.0.20. I haven't checked whether this works in our dependent projects yet.