### PR TITLE
Set JS compiler target to ES2015 in `kotlin-multiplatform-js-browser-conventions`

### DIFF
--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/kotlin-multiplatform-js-browser-conventions.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/kotlin-multiplatform-js-browser-conventions.gradle.kts
@@ -8,5 +8,9 @@ kotlin {
     js {
         //moduleName = fullNameWithRootProjectNameForFileSystem // deprecated and scheduled for removal in Kotlin 2.3
         browser()
+
+        compilerOptions {
+            target.set("es2015")
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JavaScript compiler target to ES2015 in Kotlin Multiplatform JS configuration for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->