### PR TITLE
Fix the issue in the `generate-kotlin-js-browser-webroot-for-vertx-web` plugin that "Task '...:sourcesJar' uses this output of task '...:syncJsBrowserDistributionToResourcesWebroot' without declaring an explicit or implicit dependency"

### DIFF
--- a/architecture-common-gradle-plugins/src/main/kotlin/com/huanshankeji/generate-kotlin-js-browser-webroot-for-vertx-web.gradle.kts
+++ b/architecture-common-gradle-plugins/src/main/kotlin/com/huanshankeji/generate-kotlin-js-browser-webroot-for-vertx-web.gradle.kts
@@ -40,5 +40,11 @@ afterEvaluate {
         dependsOn(syncJsBrowserDistributionToResourcesWebroot)
     }
 
+    tasks.configureEach {
+        if (name == "sourcesJar") {
+            dependsOn(syncJsBrowserDistributionToResourcesWebroot)
+        }
+    }
+
     sourceSets.main { resources.srcDir(browserDistributionResourcesDirectory) }
 }

--- a/architecture-common-gradle-plugins/src/main/kotlin/com/huanshankeji/generate-kotlin-js-browser-webroot-for-vertx-web.gradle.kts
+++ b/architecture-common-gradle-plugins/src/main/kotlin/com/huanshankeji/generate-kotlin-js-browser-webroot-for-vertx-web.gradle.kts
@@ -36,15 +36,7 @@ afterEvaluate {
         into(browserDistributionResourcesDirectory.dir(extension.webRoot.getOrElse("webroot")))
     }
 
-    tasks.named<Copy>("processResources") {
-        dependsOn(syncJsBrowserDistributionToResourcesWebroot)
+    sourceSets.main {
+        resources.srcDir(files(browserDistributionResourcesDirectory).builtBy(syncJsBrowserDistributionToResourcesWebroot))
     }
-
-    tasks.configureEach {
-        if (name == "sourcesJar") {
-            dependsOn(syncJsBrowserDistributionToResourcesWebroot)
-        }
-    }
-
-    sourceSets.main { resources.srcDir(browserDistributionResourcesDirectory) }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process to ensure proper synchronization of web resources during the build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->