### PR TITLE
Provision Temurin JDK 17 in cloud-agent base image

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,12 @@
+# Cloud-agent base image for Huanshankeji Gradle convention plugins.
+# Temurin JDK 17 matches CI (kotlin-jvm-ci.yml) and kotlin.jvmToolchain(17).
+FROM eclipse-temurin:17-jdk-noble
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        sudo \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "./gradlew --version"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud agents on the default Ubuntu base image only had OpenJDK 21, so `./gradlew check` failed with:

> Cannot find a Java installation matching: {languageVersion=17, ...}. Toolchain download repositories have not been configured.

This adds a repo-level Cursor cloud environment that builds from `eclipse-temurin:17-jdk-noble`, matching CI (`kotlin-jvm-ci.yml` uses Temurin 17) and `kotlin.jvmToolchain(17)` in `buildSrc`.

## Changes

- **`.cursor/Dockerfile`** — Temurin JDK 17 on Ubuntu Noble, plus `git` and `sudo` required by cloud agents
- **`.cursor/environment.json`** — wires the Dockerfile build and warms the Gradle wrapper via `./gradlew --version` on startup

## Verification

With Temurin 17 installed (same vendor/version family as the Docker image), `./gradlew check` completes successfully (64 tasks, BUILD SUCCESSFUL).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0d2e01d-ceda-4985-81fe-2046745b8edd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0d2e01d-ceda-4985-81fe-2046745b8edd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

