### PR TITLE
Migrate module-wide opt-ins to compilerOptions.optIn DSL

### DIFF
--- a/PLUGINS_CHANGELOG.md
+++ b/PLUGINS_CHANGELOG.md
@@ -1,5 +1,10 @@
 # "Gradle plugins" change log
 
+## v0.12.0-SNAPSHOT
+
+* migrate module-wide opt-ins to the `compilerOptions.optIn` DSL
+    * `defaultOptIns()` now extends `KotlinCommonCompilerOptions` instead of `LanguageSettingsBuilder`; call it from `kotlin { compilerOptions { ... } }` instead of `languageSettings { ... }`
+
 ## v0.11.0 / 2025-10-28
 
 * add the `maven-central-publish-conventions` plugin based on `com.vanniktech.maven.publish` and deprecate our old OSSRH publish plugins

--- a/architecture-common-gradle-plugins/api/architecture-common-gradle-plugins.api
+++ b/architecture-common-gradle-plugins/api/architecture-common-gradle-plugins.api
@@ -45,7 +45,7 @@ public abstract interface class com/huanshankeji/Generate_kotlin_js_browser_webr
 }
 
 public final class com/huanshankeji/OptInsKt {
-	public static final fun defaultOptIns (Lorg/jetbrains/kotlin/gradle/plugin/LanguageSettingsBuilder;)V
+	public static final fun defaultOptIns (Lorg/jetbrains/kotlin/gradle/dsl/KotlinCommonCompilerOptions;)V
 }
 
 public final class com/huanshankeji/jvm/native/osandarch/CpuArchitecture : java/lang/Enum {

--- a/architecture-common-gradle-plugins/src/main/kotlin/com/huanshankeji/OptIns.kt
+++ b/architecture-common-gradle-plugins/src/main/kotlin/com/huanshankeji/OptIns.kt
@@ -1,11 +1,11 @@
 package com.huanshankeji
 
-import org.jetbrains.kotlin.gradle.plugin.LanguageSettingsBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
 
-fun LanguageSettingsBuilder.defaultOptIns() {
-    optIn("kotlin.RequiresOptIn")
+fun KotlinCommonCompilerOptions.defaultOptIns() {
+    optIn.add("kotlin.RequiresOptIn")
 
-    optIn("kotlin.ExperimentalStdlibApi")
-    optIn("kotlin.ExperimentalUnsignedTypes")
-    optIn("kotlinx.serialization.ExperimentalSerializationApi")
+    optIn.add("kotlin.ExperimentalStdlibApi")
+    optIn.add("kotlin.ExperimentalUnsignedTypes")
+    optIn.add("kotlinx.serialization.ExperimentalSerializationApi")
 }

--- a/buildSrc/src/main/kotlin/aligned-version-plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/aligned-version-plugin-conventions.gradle.kts
@@ -11,5 +11,5 @@ dependencies {
 }
 
 tasks.named<KotlinCompilationTask<*>>("compileKotlin").configure {
-    compilerOptions.freeCompilerArgs.add("-opt-in=com.huanshankeji.InternalApi")
+    compilerOptions.optIn.add("com.huanshankeji.InternalApi")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates all module-wide opt-in configuration to the Kotlin Gradle Plugin's `compilerOptions.optIn` DSL, per [Kotlin opt-in requirements](https://kotlinlang.org/docs/opt-in-requirements.html) and [compiler options guidance](https://kotlinlang.org/docs/gradle-compiler-options.html).

## Changes

- **`aligned-version-plugin-conventions`**: replace `freeCompilerArgs.add("-opt-in=...")` with `compilerOptions.optIn.add("com.huanshankeji.InternalApi")` on `compileKotlin`.
- **`defaultOptIns()` helper**: change receiver from deprecated `LanguageSettingsBuilder` to `KotlinCommonCompilerOptions`, using `optIn.add(...)` instead of `optIn(...)`.

## Migration for consumers

Before:

```kotlin
kotlin {
    sourceSets.all {
        languageSettings {
            defaultOptIns()
        }
    }
}
```

After:

```kotlin
kotlin {
    compilerOptions {
        defaultOptIns()
    }
}
```

## Verification

- `./gradlew check` passes
- ABI dump updated for the intentional `defaultOptIns()` signature change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6efd899-605d-444a-b11d-36e14479cd96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6efd899-605d-444a-b11d-36e14479cd96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

