### PR TITLE
Document verified behavior of buildSrc pluginManagement vs Kotlin BOM pinning

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -7,11 +7,15 @@
 // The Kotlin Gradle plugin version for build-logic subprojects is registered in
 // `buildSrc/build.gradle.kts` (`alias(libs.plugins.kotlin.jvmWithExplicitVersion) apply false`).
 //
-// `pluginManagement { plugins { … } }` here is not sufficient on its own: it only constrains plugin
-// id resolution for the `plugins {}` DSL, while versionless `org.jetbrains.kotlin:*` catalog
-// library dependencies still follow the `kotlin-dsl` embedded Kotlin BOM (2.3.21 on Gradle 9.6)
-// until subprojects apply `kotlin("jvm")` against a plugin classpath that includes Kotlin 2.4.0.
-// The commented block below was an earlier attempt.
+// `pluginManagement { plugins { … } }` here is not sufficient on its own. It constrains plugin-id
+// resolution for the `plugins {}` DSL (so `--info` logs show `org.jetbrains.kotlin.jvm` at 2.4.0),
+// but versionless `org.jetbrains.kotlin:*` `implementation` dependencies (from the catalog) are
+// aligned by the `kotlin-gradle-plugins-bom` platform, not by `pluginManagement`. With only
+// `pluginManagement`, `kotlin-dsl`'s embedded Kotlin BOM (2.3.21 on Gradle 9.6) still wins, so
+// `kotlin-compiler-embeddable` and `kotlin-gradle-plugin` stay on 2.3.21. Registering the plugin
+// with `apply false` in the root `buildSrc` build script adds `kotlin-gradle-plugins-bom:2.4.0`
+// to the build classpath and aligns those library dependencies. The block below was an earlier
+// attempt; keep it commented out so the BOM is not pinned twice.
 /*
 pluginManagement {
     repositories {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Part of the `cursor/extract-bootstrapping-plugins-source-link-f271` work: `buildSrc` pins build-logic Kotlin to **2.4.0** via `alias(libs.plugins.kotlin.jvmWithExplicitVersion) apply false` in `buildSrc/build.gradle.kts`, not via `pluginManagement` in `buildSrc/settings.gradle.kts`.

An experiment on a side branch re-enabled `pluginManagement` alone and removed `apply false`; build scans then showed Kotlin **2.3.20/2.3.21** instead of **2.4.0**. This PR documents the verified reason and tightens the comment in `buildSrc/settings.gradle.kts`.

**No functional build changes** — only comment/documentation updates on top of the target branch.

## Verified behavior

`pluginManagement` and dependency resolution are separate:

| Mechanism | What it controls | With only `pluginManagement` |
|---|---|---|
| `pluginManagement { plugins { … } }` | Plugin-id resolution for `plugins {}` | `org.jetbrains.kotlin.jvm` resolves to **2.4.0** (`--info`: `Resolved plugin … version: '2.4.0'`) |
| Dependency resolution / BOM | Versionless `implementation(libs.kotlin.gradlePlugin)` etc. | `kotlin-dsl`'s embedded `kotlin-gradle-plugins-bom` (**2.3.21** on Gradle 9.6) wins |

So `pluginManagement` alone is insufficient: `kotlin-compiler-embeddable` and `kotlin-gradle-plugin` stay on **2.3.21** even though the plugin id resolves to 2.4.0.

`apply false` in the root `buildSrc` build script registers `kotlin-gradle-plugins-bom:2.4.0` on the build classpath and aligns library dependencies and the compiler.

## Comment updates

- Replace the misleading "until subprojects apply `kotlin("jvm")` …" wording with the plugin-id vs BOM distinction above.
- Note that the commented `pluginManagement` block is a prior attempt and should stay commented so the BOM is not pinned twice.
- Keep `kotlin("jvm") version "2.4.0"` in the commented example (valid syntax in `settings.gradle.kts`).

## Simpler version check than build scan

From `buildSrc/`:

```bash
../gradlew :kotlin-common-gradle-plugins:dependencyInsight \
  --dependency kotlin-compiler-embeddable \
  --configuration kotlinCompilerClasspath
```

- `pluginManagement` only: `kotlin-compiler-embeddable:2.3.21`
- With `apply false` (current target branch): `kotlin-compiler-embeddable:2.4.0`

The `--info` "Resolved plugin … 2.4.0" line alone is misleading; use `dependencyInsight` on the compiler classpath for the effective version.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e824b360-54c4-487a-9381-129a424152b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e824b360-54c4-487a-9381-129a424152b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

