### PR TITLE
Use GITHUB_TOKEN for GitHub Packages publish (investigation)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Publish with Gradle Wrapper
         env:
-          ORG_GRADLE_PROJECT_gprUser: ${{ secrets.GPR_USER }}
-          ORG_GRADLE_PROJECT_gprKey: ${{ secrets.GPR_KEY }}
+          ORG_GRADLE_PROJECT_gprUser: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_gprKey: ${{ secrets.GITHUB_TOKEN }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         run: |


### PR DESCRIPTION
## Summary

Draft PR documenting investigation of replacing `GPR_USER` / `GPR_KEY` with the automatically provisioned `GITHUB_TOKEN` for GitHub Packages in CI. **Closing without merge** — findings are recorded here for future reference.

### Change under test

In `publish.yml`, GitHub Packages credentials for non-`release` branch publishes were switched from org PAT secrets to:

- `ORG_GRADLE_PROJECT_gprUser: ${{ github.actor }}`
- `ORG_GRADLE_PROJECT_gprKey: ${{ secrets.GITHUB_TOKEN }}`

Existing `permissions: packages: write` on the publish job is unchanged.

### CI result

[Publish workflow run #28418650971](https://github.com/huanshankeji/gradle-common/actions/runs/28418650971) on branch `test/github-token-packages-publish` **succeeded**. All four modules published to GitHub Packages (`common-gradle-dependencies`, `kotlin-common-gradle-plugins`, `architecture-common-gradle-plugins`, `gradle-plugins`).

### `GITHUB_TOKEN` basics

- **No manual secret setup** — GitHub injects `GITHUB_TOKEN` at the start of each job when Actions is enabled on the repo.
- **Permissions are not unlimited** — scope comes from the workflow/job `permissions:` block and org/repo default workflow permissions. Omitted scopes default to `none` when `permissions:` is set explicitly.
- **Publish** requires `packages: write`; **consume** requires `packages: read` (or `write`, which includes read).

### Same-repo vs cross-repo

| Scenario | `GITHUB_TOKEN` |
|----------|----------------|
| Publish from `gradle-common` CI | ✅ Works (verified) |
| Consume inside `gradle-common` CI | ✅ Should work with `packages: read` |
| Consume from another repo (e.g. `kotlin-common`) | ❌ Not reliably available for Maven/Gradle packages |

### Why cross-repo consumption still needs a PAT

Gradle/Maven packages on GitHub are **repository-scoped** — they inherit ACL from the publishing repository and do **not** support the granular-permission UI (no “Manage Actions access” on package settings). See [About permissions for GitHub Packages — repository-scoped packages](https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#permissions-for-repository-scoped-packages).

Package settings for Maven/Gradle artifacts (e.g. [com.huanshankeji.common-gradle-dependencies](https://github.com/huanshankeji/gradle-common/packages/1644585/options)) only show **Options** / **Manage versions** — not “Manage Actions access”. That UI exists for Container/npm/NuGet/RubyGems only.

Official guidance for cross-repo install of Maven/Gradle packages: use a **classic PAT** with `read:packages` ([access tokens](https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#access-tokens)). The existing `GPR_USER` / `GPR_KEY` org secrets remain appropriate for consumer repos like `kotlin-common`.

### Recommendations

1. **Adopt `GITHUB_TOKEN` for publish** in `gradle-common` — removes need for `GPR_*` on the publish workflow path; verified in CI.
2. **Keep `GPR_USER` / `GPR_KEY`** in reusable CI workflows (`gradle-ci.yml`) and downstream repos that resolve dev dependencies from `maven.pkg.github.com/huanshankeji/gradle-common`.
3. Optionally test whether `GITHUB_TOKEN` can read **public** Maven packages cross-repo (undocumented; PAT is the reliable fallback).

## Test plan

- [x] Push to test branch triggers Publish workflow
- [x] `publishAllPublicationsToGitHubPackagesRepository` succeeds with `GITHUB_TOKEN`
- [ ] Cross-repo consume test in `kotlin-common` (not in scope for this PR)


Made with [Cursor](https://cursor.com)