### PR TITLE
Adapt Maven repository helpers to context parameters

### DIFF
--- a/huanshankeji-team-gradle-plugins/api/gradle-plugins.api
+++ b/huanshankeji-team-gradle-plugins/api/gradle-plugins.api
@@ -26,7 +26,7 @@ public final class com/huanshankeji/team/Default_github_packages_maven_publish_g
 }
 
 public final class com/huanshankeji/team/GithubPackagesMavenKt {
-	public static final fun repositoriesAddTeamGithubPackagesMavenRegistry (Lorg/gradle/api/Project;Ljava/lang/String;)V
+	public static final fun mavenTeamGithubPackagesRepository (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
 }
 
 public final class com/huanshankeji/team/GithubPackagesMavenPublishPlugin : org/gradle/api/Plugin {

--- a/huanshankeji-team-gradle-plugins/src/main/kotlin/com/huanshankeji/team/GithubPackagesMaven.kt
+++ b/huanshankeji-team-gradle-plugins/src/main/kotlin/com/huanshankeji/team/GithubPackagesMaven.kt
@@ -1,10 +1,10 @@
 package com.huanshankeji.team
 
-import com.huanshankeji.repositoriesAddGithubPackagesMavenRegistry
+import com.huanshankeji.mavenGithubPackagesRepository
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 
-@Deprecated(
-    "Use the context parameter version instead.", // TODO
-)
-fun Project.repositoriesAddTeamGithubPackagesMavenRegistry(repository: String) =
-    repositoriesAddGithubPackagesMavenRegistry(HUANSHANKEJI_IN_LOWERCASE, repository)
+context(project: Project)
+fun RepositoryHandler.mavenTeamGithubPackagesRepository(repository: String): MavenArtifactRepository =
+    mavenGithubPackagesRepository(owner = HUANSHANKEJI_IN_LOWERCASE, repository = repository)

--- a/huanshankeji-team-gradle-plugins/src/main/kotlin/com/huanshankeji/team/maven/HuanshankejiPublicMavenRepositories.kt
+++ b/huanshankeji-team-gradle-plugins/src/main/kotlin/com/huanshankeji/team/maven/HuanshankejiPublicMavenRepositories.kt
@@ -1,18 +1,14 @@
 package com.huanshankeji.team.maven
 
-import com.huanshankeji.DEV_COMMIT_VERSION_REGEX
-import com.huanshankeji.DIRTY_DEV_COMMIT_VERSION_REGEX
-import com.huanshankeji.HUANSHANKEJI_MAVEN_GROUP
-import com.huanshankeji.LEGACY_SNAPSHOT_VERSION_REGEX
 import com.huanshankeji.contentExcludeHuanshankejiNonStableVersions
-import com.huanshankeji.githubPackagesMavenPassword
-import com.huanshankeji.githubPackagesMavenUsername
+import com.huanshankeji.contentIncludeHuanshankejiDevCommitVersions
+import com.huanshankeji.contentIncludeHuanshankejiDirtyAndLegacySnapshots
+import com.huanshankeji.githubPackagesMavenRegistrySetUrlAndCredentials
 import com.huanshankeji.team.HUANSHANKEJI_IN_LOWERCASE
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.kotlin.dsl.maven
-import java.net.URI
 
 /**
  * Configures Maven local (first) and GitHub Packages for [HUANSHANKEJI_MAVEN_GROUP] artifacts.
@@ -27,21 +23,16 @@ fun RepositoryHandler.configurePublicHuanshankejiArtifactRepositories(
 ) {
     mavenLocal {
         content {
-            includeVersionByRegex(HUANSHANKEJI_MAVEN_GROUP, ".*", DEV_COMMIT_VERSION_REGEX)
-            includeVersionByRegex(HUANSHANKEJI_MAVEN_GROUP, ".*", DIRTY_DEV_COMMIT_VERSION_REGEX)
-            includeVersionByRegex(HUANSHANKEJI_MAVEN_GROUP, ".*", LEGACY_SNAPSHOT_VERSION_REGEX)
+            contentIncludeHuanshankejiDevCommitVersions()
+            contentIncludeHuanshankejiDirtyAndLegacySnapshots()
         }
     }
     for (repositoryName in githubPackageRepositoryNames) {
         maven {
             name = "GitHubPackages-$repositoryName"
-            url = URI("https://maven.pkg.github.com/$owner/$repositoryName")
-            credentials {
-                username = project.githubPackagesMavenUsername()
-                password = project.githubPackagesMavenPassword()
-            }
+            githubPackagesMavenRegistrySetUrlAndCredentials(owner, repositoryName)
             content {
-                includeVersionByRegex(HUANSHANKEJI_MAVEN_GROUP, ".*", DEV_COMMIT_VERSION_REGEX)
+                contentIncludeHuanshankejiDevCommitVersions()
             }
         }
     }

--- a/huanshankeji-team-gradle-plugins/src/main/kotlin/com/huanshankeji/team/maven/PublicOpenSourceDependencyRepositoriesExtension.kt
+++ b/huanshankeji-team-gradle-plugins/src/main/kotlin/com/huanshankeji/team/maven/PublicOpenSourceDependencyRepositoriesExtension.kt
@@ -3,20 +3,17 @@ package com.huanshankeji.team.maven
 import com.huanshankeji.contentExcludeHuanshankejiNonStableVersions
 import com.huanshankeji.contentIncludeHuanshankejiDevCommitVersions
 import com.huanshankeji.contentIncludeHuanshankejiDirtyAndLegacySnapshots
-import com.huanshankeji.githubPackagesMavenPassword
-import com.huanshankeji.githubPackagesMavenUsername
+import com.huanshankeji.githubPackagesMavenRegistrySetUrlAndCredentials
 import com.huanshankeji.team.HUANSHANKEJI_IN_LOWERCASE
-import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.initialization.Settings
-import java.net.URI
 
 /**
  * Composable DSL for public OSS repos. No repositories are added unless explicitly configured
  * in `settings.gradle.kts` after applying the settings plugin.
  */
 open class PublicOpenSourceDependencyRepositoriesExtension {
-    internal lateinit var repositories: RepositoryHandler
+    internal lateinit var repositories: org.gradle.api.artifacts.dsl.RepositoryHandler
     internal lateinit var settings: Settings
 
     fun huanshankejiMavenLocal() {
@@ -29,16 +26,14 @@ open class PublicOpenSourceDependencyRepositoriesExtension {
     }
 
     fun githubPackages(vararg repositoryNames: String, owner: String = HUANSHANKEJI_IN_LOWERCASE) {
-        for (repositoryName in repositoryNames) {
-            repositories.maven {
-                name = "GitHubPackages-$repositoryName"
-                url = URI("https://maven.pkg.github.com/$owner/$repositoryName")
-                credentials {
-                    username = settings.githubPackagesMavenUsername()
-                    password = settings.githubPackagesMavenPassword()
-                }
-                content {
-                    contentIncludeHuanshankejiDevCommitVersions()
+        with(settings) {
+            for (repositoryName in repositoryNames) {
+                repositories.maven {
+                    name = "GitHubPackages-$repositoryName"
+                    githubPackagesMavenRegistrySetUrlAndCredentials(owner, repositoryName)
+                    content {
+                        contentIncludeHuanshankejiDevCommitVersions()
+                    }
                 }
             }
         }

--- a/kotlin-common-gradle-plugins/api/kotlin-common-gradle-plugins.api
+++ b/kotlin-common-gradle-plugins/api/kotlin-common-gradle-plugins.api
@@ -60,10 +60,14 @@ public final class com/huanshankeji/GithubPackagesMavenPublishPlugin : org/gradl
 
 public final class com/huanshankeji/GithubPackagesMavenRegistryKt {
 	public static final fun githubPackagesMavenRegistrySetUrlAndCredentials (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun githubPackagesMavenRegistrySetUrlAndCredentials (Lorg/gradle/api/initialization/Settings;Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun mavenGithubPackagesRepository (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
+	public static final fun mavenGithubPackagesRepository (Lorg/gradle/api/initialization/Settings;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
+	public static synthetic fun mavenGithubPackagesRepository$default (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
+	public static synthetic fun mavenGithubPackagesRepository$default (Lorg/gradle/api/initialization/Settings;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
 	public static final fun publishing (Lorg/gradle/api/Project;Lorg/gradle/api/Action;)V
 	public static final fun publishingRepositoriesAddGithubPackagesMavenRepository (Lorg/gradle/api/Project;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static synthetic fun publishingRepositoriesAddGithubPackagesMavenRepository$default (Lorg/gradle/api/Project;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public static final fun repositoriesAddGithubPackagesMavenRegistry (Lorg/gradle/api/Project;Ljava/lang/String;Ljava/lang/String;)V
 }
 
 public final class com/huanshankeji/Github_packages_maven_publish_gradle : org/gradle/kotlin/dsl/precompile/v1/PrecompiledProjectScript {
@@ -80,8 +84,6 @@ public abstract interface class com/huanshankeji/Github_packages_maven_publish_g
 public final class com/huanshankeji/GitlabPackageRegistryMavenKt {
 	public static final field GITLAB_COM_HOST Ljava/lang/String;
 	public static final field GITLAB_PACKAGE_REGISTRY_REPOSITORY_NAME Ljava/lang/String;
-	public static final fun gitlabMavenRepository (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
-	public static synthetic fun gitlabMavenRepository$default (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
 	public static final fun gitlabPackageRegistryGroupLevelMavenRepository (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
 	public static synthetic fun gitlabPackageRegistryGroupLevelMavenRepository$default (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
 	public static final fun gitlabPackageRegistryInstanceLevelMavenRepository (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
@@ -89,6 +91,8 @@ public final class com/huanshankeji/GitlabPackageRegistryMavenKt {
 	public static final fun gitlabPackageRegistryMavenRepositorySetUrlAndCredentials (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun gitlabPackageRegistryProjectLevelMavenRepository (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
 	public static synthetic fun gitlabPackageRegistryProjectLevelMavenRepository$default (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
+	public static final fun mavenGitlabPackageRegistryRepository (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
+	public static synthetic fun mavenGitlabPackageRegistryRepository$default (Lorg/gradle/api/Project;Lorg/gradle/api/artifacts/dsl/RepositoryHandler;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/artifacts/repositories/MavenArtifactRepository;
 }
 
 public final class com/huanshankeji/GitlabPackageRegistryProjectLevelMavenEndpointPublishPlugin : org/gradle/api/Plugin {

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/GithubPackagesMavenRegistry.kt
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/GithubPackagesMavenRegistry.kt
@@ -2,9 +2,12 @@ package com.huanshankeji
 
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.initialization.Settings
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.kotlin.dsl.repositories
+import java.net.URI
 
 context(project: Project)
 fun MavenArtifactRepository.githubPackagesMavenRegistrySetUrlAndCredentials(owner: String, repository: String) {
@@ -15,33 +18,50 @@ fun MavenArtifactRepository.githubPackagesMavenRegistrySetUrlAndCredentials(owne
     }
 }
 
-@Deprecated(
-    "Use the context parameter version instead.", // TODO
-)
-fun Project.repositoriesAddGithubPackagesMavenRegistry(owner: String, repository: String) =
-    repositories {
-        maven {
-            with(this@repositoriesAddGithubPackagesMavenRegistry) {
-                githubPackagesMavenRegistrySetUrlAndCredentials(owner, repository)
-            }
-        }
+context(settings: Settings)
+fun MavenArtifactRepository.githubPackagesMavenRegistrySetUrlAndCredentials(owner: String, repository: String) {
+    url = URI("https://maven.pkg.github.com/$owner/$repository")
+    credentials {
+        username = settings.githubPackagesMavenUsername()
+        password = settings.githubPackagesMavenPassword()
+    }
+}
+
+context(project: Project)
+fun RepositoryHandler.mavenGithubPackagesRepository(
+    nameArg: String = "GitHubPackages",
+    owner: String,
+    repository: String,
+): MavenArtifactRepository =
+    maven {
+        name = nameArg
+        githubPackagesMavenRegistrySetUrlAndCredentials(owner, repository)
+    }
+
+context(settings: Settings)
+fun RepositoryHandler.mavenGithubPackagesRepository(
+    nameArg: String = "GitHubPackages",
+    owner: String,
+    repository: String,
+): MavenArtifactRepository =
+    maven {
+        name = nameArg
+        githubPackagesMavenRegistrySetUrlAndCredentials(owner, repository)
     }
 
 fun Project.publishingRepositoriesAddGithubPackagesMavenRepository(
     nameArg: String = "GitHubPackages",
     owner: String,
     repository: String,
-) =
-    publishing {
-        repositories {
-            maven {
-                name = nameArg
-                with(this@publishingRepositoriesAddGithubPackagesMavenRepository) {
-                    githubPackagesMavenRegistrySetUrlAndCredentials(owner, repository)
-                }
+) {
+    with(this) {
+        publishing {
+            repositories {
+                mavenGithubPackagesRepository(nameArg, owner, repository)
             }
         }
     }
+}
 
 fun Project.publishing(configure: Action<PublishingExtension>): Unit =
     extensions.configure("publishing", configure)

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/GitlabPackageRegistryMaven.kt
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/GitlabPackageRegistryMaven.kt
@@ -25,39 +25,37 @@ fun MavenArtifactRepository.gitlabPackageRegistryMavenRepositorySetUrlAndCredent
     }
 }
 
-@Deprecated(
-    "Use the context parameter version instead.", // TODO
-)
-fun Project.gitlabMavenRepository(repositoryHandler: RepositoryHandler, nameArg: String = "GitLab", urlArg: String) =
-    repositoryHandler.maven {
-        with(this@gitlabMavenRepository) {
-            gitlabPackageRegistryMavenRepositorySetUrlAndCredentials(nameArg, urlArg)
-        }
+context(project: Project)
+fun RepositoryHandler.mavenGitlabPackageRegistryRepository(
+    nameArg: String = "GitLab",
+    urlArg: String,
+): MavenArtifactRepository =
+    maven {
+        gitlabPackageRegistryMavenRepositorySetUrlAndCredentials(nameArg, urlArg)
     }
 
-fun Project.gitlabPackageRegistryProjectLevelMavenRepository(
-    repositoryHandler: RepositoryHandler,
+context(project: Project)
+fun RepositoryHandler.gitlabPackageRegistryProjectLevelMavenRepository(
     name: String = GITLAB_PACKAGE_REGISTRY_REPOSITORY_NAME,
     host: String = GITLAB_COM_HOST,
     projectIdOrProjectPath: String,
 ): MavenArtifactRepository =
-    gitlabMavenRepository(
-        repositoryHandler,
+    mavenGitlabPackageRegistryRepository(
         name,
         "https://$host/api/v4/projects/$projectIdOrProjectPath/packages/maven",
     )
 
-fun Project.gitlabPackageRegistryGroupLevelMavenRepository(
-    repositoryHandler: RepositoryHandler,
+context(project: Project)
+fun RepositoryHandler.gitlabPackageRegistryGroupLevelMavenRepository(
     name: String = GITLAB_PACKAGE_REGISTRY_REPOSITORY_NAME,
     host: String = GITLAB_COM_HOST,
     groupId: String,
 ): MavenArtifactRepository =
-    gitlabMavenRepository(repositoryHandler, name, "https://$host/api/v4/groups/$groupId/-/packages/maven")
+    mavenGitlabPackageRegistryRepository(name, "https://$host/api/v4/groups/$groupId/-/packages/maven")
 
-fun Project.gitlabPackageRegistryInstanceLevelMavenRepository(
-    repositoryHandler: RepositoryHandler,
+context(project: Project)
+fun RepositoryHandler.gitlabPackageRegistryInstanceLevelMavenRepository(
     name: String = GITLAB_PACKAGE_REGISTRY_REPOSITORY_NAME,
     host: String,
 ): MavenArtifactRepository =
-    gitlabMavenRepository(repositoryHandler, name, "https://$host/api/v4/packages/maven")
+    mavenGitlabPackageRegistryRepository(name, "https://$host/api/v4/packages/maven")

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/gitlab-package-registry-project-level-maven-endpoint-publish.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/gitlab-package-registry-project-level-maven-endpoint-publish.gradle.kts
@@ -18,13 +18,14 @@ interface Extension {
 val extension = extensions.create<Extension>("gitlabPackageRegistryProjectLevelMavenEndpointPublish")
 
 afterEvaluate {
-    publishing {
-        repositories {
-            gitlabPackageRegistryProjectLevelMavenRepository(
-                this,
-                host = extension.host.getOrElse(GITLAB_COM_HOST),
-                projectIdOrProjectPath = extension.projectId.get(),
-            )
+    with(this) {
+        publishing {
+            repositories {
+                gitlabPackageRegistryProjectLevelMavenRepository(
+                    host = extension.host.getOrElse(GITLAB_COM_HOST),
+                    projectIdOrProjectPath = extension.projectId.get(),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the PR #56 review TODO: **Adapt to context parameters completely and check whether it works.**

The previous migration introduced `context(project: Project)` on `MavenArtifactRepository` helpers but left deprecated `Project` wrappers and awkward `with(project)` call sites. This change finishes the migration:

- **GitHub Packages** (`GithubPackagesMavenRegistry.kt`): removed deprecated `repositoriesAddGithubPackagesMavenRegistry`; added `RepositoryHandler.mavenGithubPackagesRepository` with `Project` and `Settings` context overloads; `publishingRepositoriesAddGithubPackagesMavenRepository` now delegates through context APIs.
- **GitLab Package Registry** (`GitlabPackageRegistryMaven.kt`): removed deprecated `gitlabMavenRepository`; repository-level helpers are now `RepositoryHandler` context extensions (`mavenGitlabPackageRegistryRepository`, `gitlabPackageRegistryProjectLevelMavenRepository`, etc.).
- **Team helpers**: replaced deprecated `repositoriesAddTeamGithubPackagesMavenRegistry` with `RepositoryHandler.mavenTeamGithubPackagesRepository`; refactored `HuanshankejiPublicMavenRepositories` and `PublicOpenSourceDependencyRepositoriesExtension` to reuse shared context-parameter credential helpers.
- **Script plugins**: updated `gitlab-package-registry-project-level-maven-endpoint-publish.gradle.kts` to call context APIs via `with(this) { publishing { repositories { … } } }`.
- **ABI dumps** updated for intentional public API changes.

## Test plan

- [x] `./gradlew check --no-daemon`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e746347d-e776-474a-80df-d9831dc5a0ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e746347d-e776-474a-80df-d9831dc5a0ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

