### PR TITLE
Remove afterEvaluate from git-version and publish plugins (Provider APIs)

### DIFF
--- a/kotlin-common-gradle-plugins/api/kotlin-common-gradle-plugins.api
+++ b/kotlin-common-gradle-plugins/api/kotlin-common-gradle-plugins.api
@@ -22,7 +22,12 @@ public final class com/huanshankeji/GenerateKotlinSourcesKt {
 	public static final fun generateRootProjectName (Lorg/gradle/api/Project;)V
 }
 
+public abstract interface class com/huanshankeji/GitVersionExtension {
+	public abstract fun getBaseVersion ()Lorg/gradle/api/provider/Property;
+}
+
 public final class com/huanshankeji/GitVersionKt {
+	public static final fun asLazyProjectVersion (Lorg/gradle/api/provider/Provider;)Ljava/lang/Object;
 	public static final fun devCommitVersionProvider (Lorg/gradle/api/Project;Ljava/lang/String;)Lorg/gradle/api/provider/Provider;
 	public static final fun devCommitVersionString (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
 	public static final fun gitCommitHash (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
@@ -33,7 +38,10 @@ public final class com/huanshankeji/GitVersionKt {
 	public static final fun isReleaseBranch (Lorg/gradle/api/Project;Ljava/lang/String;)Lorg/gradle/api/provider/Provider;
 	public static synthetic fun isReleaseBranch$default (Lorg/gradle/api/Project;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/provider/Provider;
 	public static final fun projectVersionFromGitProvider (Lorg/gradle/api/Project;Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/provider/Provider;
+	public static final fun projectVersionFromGitProvider (Lorg/gradle/api/Project;Lorg/gradle/api/provider/Provider;Ljava/lang/String;)Lorg/gradle/api/provider/Provider;
 	public static synthetic fun projectVersionFromGitProvider$default (Lorg/gradle/api/Project;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/provider/Provider;
+	public static synthetic fun projectVersionFromGitProvider$default (Lorg/gradle/api/Project;Lorg/gradle/api/provider/Provider;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/provider/Provider;
+	public static final fun wireGitVersionToProjectVersion (Lorg/gradle/api/Project;)V
 }
 
 public final class com/huanshankeji/GitVersionPlugin : org/gradle/api/Plugin {
@@ -44,12 +52,7 @@ public final class com/huanshankeji/GitVersionPlugin : org/gradle/api/Plugin {
 
 public final class com/huanshankeji/Git_version_gradle : org/gradle/kotlin/dsl/precompile/v1/PrecompiledProjectScript {
 	public fun <init> (Lorg/gradle/api/Project;Lorg/gradle/api/Project;)V
-	public final fun getExtension ()Lcom/huanshankeji/Git_version_gradle$GitVersionExtension;
 	public static final fun main ([Ljava/lang/String;)V
-}
-
-public abstract interface class com/huanshankeji/Git_version_gradle$GitVersionExtension {
-	public abstract fun getBaseVersion ()Lorg/gradle/api/provider/Property;
 }
 
 public final class com/huanshankeji/GithubPackagesMavenPublishPlugin : org/gradle/api/Plugin {
@@ -218,6 +221,7 @@ public final class com/huanshankeji/MavenRepositoryVersionsKt {
 public final class com/huanshankeji/Maven_central_publish_conventions_gradle : org/gradle/kotlin/dsl/precompile/v1/PrecompiledProjectScript {
 	public fun <init> (Lorg/gradle/api/Project;Lorg/gradle/api/Project;)V
 	public static final fun main ([Ljava/lang/String;)V
+	public final fun wireMavenCentralSigning (Lorg/gradle/api/provider/Provider;)V
 }
 
 public final class com/huanshankeji/NamingConventionsKt {
@@ -237,6 +241,7 @@ public final class com/huanshankeji/ProjectNamesKt {
 }
 
 public final class com/huanshankeji/SnapshotAndReleaseVersionsKt {
+	public static final fun isMavenCentralSigningVersion (Ljava/lang/String;)Z
 	public static final fun isSnapshotVersion (Lorg/gradle/api/Project;)Z
 }
 

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/GitVersion.kt
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/GitVersion.kt
@@ -1,6 +1,7 @@
 package com.huanshankeji
 
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
 fun Project.gitCommitHash(): Provider<String> =
@@ -36,6 +37,16 @@ fun Project.devCommitVersionProvider(baseVersion: String): Provider<String> =
  * Returns [baseVersion] on [releaseBranch]; otherwise a dev-commit version from Git.
  * Override with the Gradle property `com.huanshankeji.forceReleaseVersion=true` when needed.
  */
+interface GitVersionExtension {
+    val baseVersion: Property<String>
+}
+
+fun Project.projectVersionFromGitProvider(
+    baseVersion: Provider<String>,
+    releaseBranch: String = "release",
+): Provider<String> =
+    baseVersion.flatMap { projectVersionFromGitProvider(it, releaseBranch) }
+
 fun Project.projectVersionFromGitProvider(
     baseVersion: String,
     releaseBranch: String = "release",
@@ -50,6 +61,16 @@ fun Project.projectVersionFromGitProvider(
             else devCommitVersionProvider(baseVersion)
         }
     }
+}
+
+/**
+ * A [Project.version] value that resolves lazily via [Provider.get] when Gradle calls [toString].
+ *
+ * See [Gradle issue #15088](https://github.com/gradle/gradle/issues/15088) and
+ * [Avoid afterEvaluate](https://docs.gradle.org/current/userguide/best_practices_general.html#avoid_afterevaluate).
+ */
+fun Provider<String>.asLazyProjectVersion(): Any = object {
+    override fun toString(): String = this@asLazyProjectVersion.get()
 }
 
 fun Project.isDirtyDevCommitVersion(): Boolean =

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/GitVersion.kt
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/GitVersion.kt
@@ -66,11 +66,19 @@ fun Project.projectVersionFromGitProvider(
 /**
  * A [Project.version] value that resolves lazily via [Provider.get] when Gradle calls [toString].
  *
+ * If the provider has no value yet (for example [GitVersionExtension.baseVersion] is configured
+ * later in the build script), returns `"unspecified"` so plugin application order stays flexible.
+ *
  * See [Gradle issue #15088](https://github.com/gradle/gradle/issues/15088) and
  * [Avoid afterEvaluate](https://docs.gradle.org/current/userguide/best_practices_general.html#avoid_afterevaluate).
  */
 fun Provider<String>.asLazyProjectVersion(): Any = object {
-    override fun toString(): String = this@asLazyProjectVersion.get()
+    override fun toString(): String = runCatching { get() }.getOrElse { "unspecified" }
+}
+
+fun Project.wireGitVersionToProjectVersion() {
+    val extension = extensions.getByName("gitVersion") as GitVersionExtension
+    version = projectVersionFromGitProvider(extension.baseVersion).asLazyProjectVersion()
 }
 
 fun Project.isDirtyDevCommitVersion(): Boolean =

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/SnapshotAndReleaseVersions.kt
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/SnapshotAndReleaseVersions.kt
@@ -4,3 +4,8 @@ import org.gradle.api.Project
 
 fun Project.isSnapshotVersion() =
     version.toString().endsWith("SNAPSHOT")
+
+fun isMavenCentralSigningVersion(version: String): Boolean =
+    !version.endsWith("SNAPSHOT") &&
+        !version.contains("-dev-commit-") &&
+        !version.endsWith("-dirty-SNAPSHOT")

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/git-version.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/git-version.gradle.kts
@@ -1,5 +1,5 @@
 package com.huanshankeji
 
-val extension = extensions.create<GitVersionExtension>("gitVersion")
+extensions.create<GitVersionExtension>("gitVersion")
 
-version = projectVersionFromGitProvider(extension.baseVersion).asLazyProjectVersion()
+wireGitVersionToProjectVersion()

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/git-version.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/git-version.gradle.kts
@@ -1,13 +1,5 @@
 package com.huanshankeji
 
-import org.gradle.api.provider.Property
-
-interface GitVersionExtension {
-    val baseVersion: Property<String>
-}
-
 val extension = extensions.create<GitVersionExtension>("gitVersion")
 
-afterEvaluate {
-    version = projectVersionFromGitProvider(extension.baseVersion.get()).get()
-}
+version = projectVersionFromGitProvider(extension.baseVersion).asLazyProjectVersion()

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/github-packages-maven-publish.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/github-packages-maven-publish.gradle.kts
@@ -1,5 +1,9 @@
 package com.huanshankeji
 
+import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.credentials
+
 plugins {
     /*
     This plugin has special fast-path / custom behavior only for Maven Central,
@@ -17,9 +21,17 @@ interface Extension {
 
 val extension = extensions.create<Extension>("githubPackagesPublish")
 
-afterEvaluate {
-    publishingRepositoriesAddGithubPackagesMavenRepository(
-        owner = extension.owner.get(),
-        repository = extension.repository.get()
-    )
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = extension.owner.zip(extension.repository) { owner, repository ->
+                uri("https://maven.pkg.github.com/$owner/$repository")
+            }
+            credentials(PasswordCredentials::class) {
+                username = githubPackagesMavenUsername()
+                password = githubPackagesMavenPassword()
+            }
+        }
+    }
 }

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/github-packages-maven-publish.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/github-packages-maven-publish.gradle.kts
@@ -1,6 +1,6 @@
 package com.huanshankeji
 
-import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.credentials
 
@@ -25,9 +25,11 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = extension.owner.zip(extension.repository) { owner, repository ->
-                uri("https://maven.pkg.github.com/$owner/$repository")
-            }
+            setUrl(
+                extension.owner.zip(extension.repository) { owner, repository ->
+                    uri("https://maven.pkg.github.com/$owner/$repository")
+                },
+            )
             credentials(PasswordCredentials::class) {
                 username = githubPackagesMavenUsername()
                 password = githubPackagesMavenPassword()

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/gitlab-package-registry-project-level-maven-endpoint-publish.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/gitlab-package-registry-project-level-maven-endpoint-publish.gradle.kts
@@ -1,5 +1,11 @@
 package com.huanshankeji
 
+import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.api.provider.Property
+import org.gradle.authentication.http.HttpHeaderAuthentication
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.credentials
+
 plugins {
     /*
     This plugin has special fast-path / custom behavior only for Maven Central,
@@ -17,14 +23,21 @@ interface Extension {
 
 val extension = extensions.create<Extension>("gitlabPackageRegistryProjectLevelMavenEndpointPublish")
 
-afterEvaluate {
-    publishing {
-        repositories {
-            gitlabPackageRegistryProjectLevelMavenRepository(
-                this,
-                host = extension.host.getOrElse(GITLAB_COM_HOST),
-                projectIdOrProjectPath = extension.projectId.get(),
-            )
+publishing {
+    repositories {
+        maven {
+            name = GITLAB_PACKAGE_REGISTRY_REPOSITORY_NAME
+            val host = extension.host.orElse(GITLAB_COM_HOST)
+            url = host.zip(extension.projectId) { resolvedHost, projectId ->
+                uri("https://$resolvedHost/api/v4/projects/$projectId/packages/maven")
+            }
+            credentials(HttpHeaderCredentials::class) {
+                name = "Private-Token"
+                value = gitlabPackageRegistryPrivateToken()
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
+            }
         }
     }
 }

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/gitlab-package-registry-project-level-maven-endpoint-publish.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/gitlab-package-registry-project-level-maven-endpoint-publish.gradle.kts
@@ -28,9 +28,11 @@ publishing {
         maven {
             name = GITLAB_PACKAGE_REGISTRY_REPOSITORY_NAME
             val host = extension.host.orElse(GITLAB_COM_HOST)
-            url = host.zip(extension.projectId) { resolvedHost, projectId ->
-                uri("https://$resolvedHost/api/v4/projects/$projectId/packages/maven")
-            }
+            setUrl(
+                host.zip(extension.projectId) { resolvedHost, projectId ->
+                    uri("https://$resolvedHost/api/v4/projects/$projectId/packages/maven")
+                },
+            )
             credentials(HttpHeaderCredentials::class) {
                 name = "Private-Token"
                 value = gitlabPackageRegistryPrivateToken()

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/maven-central-publish-conventions.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/maven-central-publish-conventions.gradle.kts
@@ -1,5 +1,7 @@
 package com.huanshankeji
 
+import org.gradle.api.provider.Provider
+
 plugins {
     id("com.vanniktech.maven.publish")
 }
@@ -8,13 +10,20 @@ mavenPublishing {
     publishToMavenCentral()
 }
 
-/*
-Currently added to wait for the version to resolve.
-TODO Avoid `afterEvaluate` and put this back into `mavenPublishing` above by refactoring related plugins to use `Provider` APIs.
- */
-afterEvaluate {
-    if (!isSnapshotVersion() && !isDirtyDevCommitVersion() && !isDevCommitVersion())
-        mavenPublishing.signAllPublications()
+fun wireMavenCentralSigning(versionProvider: Provider<String>) {
+    version = versionProvider.map { version ->
+        if (isMavenCentralSigningVersion(version)) mavenPublishing.signAllPublications()
+        version
+    }.asLazyProjectVersion()
+}
+
+pluginManager.withPlugin("com.huanshankeji.git-version") {
+    wireMavenCentralSigning(
+        projectVersionFromGitProvider(extensions.getByType<GitVersionExtension>().baseVersion),
+    )
+}
+if (!plugins.hasPlugin("com.huanshankeji.git-version")) {
+    wireMavenCentralSigning(providers.provider { version.toString() })
 }
 
 // should probably require the Java toolchain version to be set too when using this plugin

--- a/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/maven-central-publish-conventions.gradle.kts
+++ b/kotlin-common-gradle-plugins/src/main/kotlin/com/huanshankeji/maven-central-publish-conventions.gradle.kts
@@ -18,9 +18,8 @@ fun wireMavenCentralSigning(versionProvider: Provider<String>) {
 }
 
 pluginManager.withPlugin("com.huanshankeji.git-version") {
-    wireMavenCentralSigning(
-        projectVersionFromGitProvider(extensions.getByType<GitVersionExtension>().baseVersion),
-    )
+    val gitVersion = extensions.getByName("gitVersion") as GitVersionExtension
+    wireMavenCentralSigning(projectVersionFromGitProvider(gitVersion.baseVersion))
 }
 if (!plugins.hasPlugin("com.huanshankeji.git-version")) {
     wireMavenCentralSigning(providers.provider { version.toString() })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the PR #56 review TODO: **"Try getting rid of `afterEvaluate` with the better Gradle paradigm"** for the git-version and Maven publish plugins introduced on `improve-cross-repo-dependency`.

Follows [Gradle best practices: Avoid afterEvaluate](https://docs.gradle.org/current/userguide/best_practices_general.html#avoid_afterevaluate) and the related [Properties and Providers](https://docs.gradle.org/current/userguide/properties_providers.html) guidance.

### Changes

| Plugin | Before | After |
|--------|--------|-------|
| `com.huanshankeji.git-version` | `afterEvaluate { version = … }` | Lazy `Provider` chain via `wireGitVersionToProjectVersion()` and `asLazyProjectVersion()` |
| `com.huanshankeji.maven-central-publish-conventions` | `afterEvaluate` signing guard | `pluginManager.withPlugin` + version `Provider` chain; signing configured when version resolves |
| `com.huanshankeji.github-packages-maven-publish` | `afterEvaluate` repository setup | `publishing.repositories.maven { setUrl(owner.zip(repository)…) }` |
| `com.huanshankeji.gitlab-package-registry-project-level-maven-endpoint-publish` | `afterEvaluate` repository setup | Lazy `Property.zip` URL wiring |

### New helpers (`GitVersion.kt`, `SnapshotAndReleaseVersions.kt`)

- `GitVersionExtension` moved to `GitVersion.kt` (shared across plugins)
- `projectVersionFromGitProvider(baseVersion: Provider<String>)` overload
- `Provider<String>.asLazyProjectVersion()` — lazy `Project.version` compatible with Gradle's toString-based resolution ([gradle#15088](https://github.com/gradle/gradle/issues/15088))
- `wireGitVersionToProjectVersion()`
- `isMavenCentralSigningVersion(version: String)` — preserves the dev-commit signing guard from commit `b1d2ff0`

### Out of scope

Pre-existing `afterEvaluate` in kotlinx-benchmark convention plugins (separate concern; noted in their file comments).

## Test plan

- [x] `./gradlew check --no-daemon`
- [x] `./gradlew publishToMavenLocal --no-daemon`
- [x] Verified `:kotlin-common-gradle-plugins:properties` reports a git-derived dev-commit version
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9b194be-cc6e-4162-a8fe-ec502e4def16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9b194be-cc6e-4162-a8fe-ec502e4def16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

